### PR TITLE
Code updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Update your security.yml file to mirror the following config
     
 ```yaml
 security:
-    enable_authenticator_manager: true
     providers:
         app_user_provider:
             entity:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Add the following ENV variables to your .env file
 ```dotenv
 AZURE_CLIENT_ID= #Your client id
 AZURE_CLIENT_SECRET= #Your client secret
-AZURE_TENANT_ID= #Your tenant id
+AZURE_TENANT= #Your tenant id
 ```
 
 ## Configure the routes

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "thenetworg/oauth2-azure": "^2.1",
         "symfony/security-bundle": "^7.0",
         "doctrine/doctrine-bundle": "^2.9",
-        "doctrine/orm": "^2.14",
+        "doctrine/orm": "^2.14 || ^3.3",
         "symfony/translation": "^7.0"
     },
     "autoload": {

--- a/src/Controller/AzureController.php
+++ b/src/Controller/AzureController.php
@@ -4,27 +4,30 @@ namespace SumoCoders\OAuthBundle\Controller;
 
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
 class AzureController extends AbstractController
 {
     #[Route('/connect/azure', name: 'connect_azure_start')]
-    public function connectAction(ClientRegistry $clientRegistry)
+    public function connectAction(ClientRegistry $clientRegistry): RedirectResponse
     {
         return $clientRegistry
             ->getClient('azure')
-            ->redirect([
+            ->redirect(
+                [
                     "openid",
                     "profile",
                     "email",
                     "offline_access",
-                ]
+                ],
+                []
             );
     }
 
     #[Route('/connect/azure/check', name: 'connect_azure_check')]
-    public function connectCheckAction(Request $request, ClientRegistry $clientRegistry)
+    public function connectCheckAction(Request $request, ClientRegistry $clientRegistry): void
     {
         // We handle the callback in the authenticator
     }

--- a/src/Security/AzureAuthenticator.php
+++ b/src/Security/AzureAuthenticator.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -25,7 +26,7 @@ use TheNetworg\OAuth2\Client\Provider\AzureResourceOwner;
 
 class AzureAuthenticator extends OAuth2Authenticator implements AuthenticationEntryPointInterface
 {
-    const ORIGIN = 'azure';
+    public const ORIGIN = 'azure';
 
     public function __construct(
         private readonly LoggerInterface $logger,
@@ -108,10 +109,13 @@ class AzureAuthenticator extends OAuth2Authenticator implements AuthenticationEn
     {
         $this->logger->error($exception->getMessage(), ['exception' => $exception]);
 
-        $this->requestStack->getSession()->getFlashBag()->add(
-            'error',
-            $this->translator->trans('login.error', [], 'azure')
-        );
+        $session = $this->requestStack->getSession();
+        if ($session instanceof FlashBagAwareSessionInterface) {
+            $session->getFlashBag()->add(
+                'error',
+                $this->translator->trans('login.error', [], 'azure')
+            );
+        }
 
         return new RedirectResponse(
             $this->router->generate($this->failureRoute)


### PR DESCRIPTION
- Allow doctrine orm v3
- Remove enable_authenticator_manager
- Phpstan fixes

## Summary by Sourcery

Adapt code to support Doctrine ORM v3, remove deprecated config, and apply PHPStan-driven code improvements.

Bug Fixes:
- Prevent potential session errors by checking session interface before accessing flash bag.

Enhancements:
- Make AzureAuthenticator.ORIGIN constant explicitly public.
- Add FlashBagAwareSessionInterface guard when setting flash messages in authenticator.
- Specify return types for AzureController methods.
- Refactor redirect scopes parameter formatting in AzureController.

Build:
- Allow doctrine/orm version 3 by widening package constraint.

Documentation:
- Remove obsolete enable_authenticator_manager option in README.
- Update Azure tenant environment variable name from AZURE_TENANT_ID to AZURE_TENANT in documentation.