### PR TITLE
Multiple clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,16 @@ Define the extra custom authenticators in services.yaml
 
 The client parameter should be the same as defined in knpu_oauth2_client (see below)
 
+Optionally use a different user class that implements SumoCoders\OAuthBundle\Entity\UserInterface,
+also update the user provider in that case.
+
 ```yaml
 services:
     azure_authenticator_sumocoders:
         class: SumoCoders\OAuthBundle\Security\AzureAuthenticator
         arguments:
             $client: 'sumocoders'
+            $userClass: App\Entity\User\User
 ```
 
 Add the following ENV variables to your .env file

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Full article: [Add app roles to your application and receive them in the token](
 Full article: [Assign users and groups to roles](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-add-app-roles-in-azure-ad-apps#assign-users-and-groups-to-roles)
 
 ## Configure the application
+This example shows two applications, the default 'azure' and 'sumocoders'.
+
 Add the needed bundles to your bundles.php file
 
 ```php
@@ -81,25 +83,74 @@ security:
         main:
             lazy: true
             provider: app_user_provider
+            entry_point: SumoCoders\OAuthBundle\Security\AzureAuthenticator
             custom_authenticators:
                 - SumoCoders\OAuthBundle\Security\AzureAuthenticator
+                - azure_authenticator_sumocoders
             logout:
                 path: logout
                 target: home #Your home page
 ```
+
+Define the extra custom authenticators in services.yaml
+
+The client parameter should be the same as defined in knpu_oauth2_client (see below)
+
+```yaml
+services:
+    azure_authenticator_sumocoders:
+        class: SumoCoders\OAuthBundle\Security\AzureAuthenticator
+        arguments:
+            $client: 'sumocoders'
+```
+
 Add the following ENV variables to your .env file
 
 ```dotenv
 AZURE_CLIENT_ID= #Your client id
 AZURE_CLIENT_SECRET= #Your client secret
 AZURE_TENANT= #Your tenant id
+
+SUMOCODERS_CLIENT_ID=
+SUMOCODERS_CLIENT_SECRET=
+SUMOCODERS_TENANT=
 ```
 
 ## Configure the routes
 Add the following routes to your routes.yaml file
 
+Make sure the prefix of the extra routes is the same as the client name.
+
 ```yaml
 oauth_bundle:
     resource: '@SumoCodersOAuthBundle/config/routes.yaml'
     prefix: /
+
+oauth_bundle_sumocoders:
+    resource: '@SumoCodersOAuthBundle/config/routes.yaml'
+    prefix: /sumocoders
+    name_prefix: sumocoders_
+```
+
+## Configure the OAuth bundle
+Add the following clients to your knpu_oauth2_client.yaml file
+
+```yaml
+knpu_oauth2_client:
+    clients:
+        azure:
+            type: azure
+            client_id: '%env(AZURE_CLIENT_ID)%'
+            client_secret: '%env(AZURE_CLIENT_SECRET)%'
+            redirect_route: connect_azure_check
+            default_end_point_version: 2.0
+            tenant: '%env(AZURE_TENANT)%'
+
+        sumocoders:
+            type: azure
+            client_id: '%env(SUMOCODERS_CLIENT_ID)%'
+            client_secret: '%env(SUMOCODERS_CLIENT_SECRET)%'
+            redirect_route: sumocoders_connect_azure_check
+            default_end_point_version: 2.0
+            tenant: '%env(SUMOCODERS_TENANT)%'
 ```

--- a/src/Controller/AzureController.php
+++ b/src/Controller/AzureController.php
@@ -11,10 +11,11 @@ use Symfony\Component\Routing\Annotation\Route;
 class AzureController extends AbstractController
 {
     #[Route('/connect/azure', name: 'connect_azure_start')]
-    public function connectAction(ClientRegistry $clientRegistry): RedirectResponse
+    public function connectAction(Request $request, ClientRegistry $clientRegistry): RedirectResponse
     {
+        $prefix = substr($request->attributes->get('_route'), 0, -20);
         return $clientRegistry
-            ->getClient('azure')
+            ->getClient($prefix === '' ? 'azure' : $prefix)
             ->redirect(
                 [
                     "openid",

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -4,7 +4,6 @@ namespace SumoCoders\OAuthBundle\Entity;
 
 use SumoCoders\OAuthBundle\Repository\UserRepository;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[ORM\UniqueConstraint(name: 'user_external_id_origin', columns: ['external_id', 'origin'])]
@@ -38,6 +37,15 @@ class User implements UserInterface
         $this->externalId = $externalId;
         $this->origin = $origin;
         $this->roles = $roles;
+    }
+
+    public static function fromAzure(
+        string $name,
+        string $externalId,
+        string $origin,
+        array $roles
+    ): self {
+        return new self($name, $externalId, $origin, $roles);
     }
 
     public function getId(): ?int

--- a/src/Entity/UserInterface.php
+++ b/src/Entity/UserInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SumoCoders\OAuthBundle\Entity;
+
+use SumoCoders\OAuthBundle\Repository\UserRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
+
+interface UserInterface extends SymfonyUserInterface
+{
+    /** @param string[] $roles */
+    public static function fromAzure(
+        string $name,
+        string $externalId,
+        string $origin,
+        array $roles
+    ): self;
+
+    public function getName();
+
+    public function getExternalId();
+
+    public function getOrigin();
+
+    /** @param string[] $roles */
+    public function setRoles(array $roles);
+}

--- a/src/Entity/UserInterface.php
+++ b/src/Entity/UserInterface.php
@@ -16,12 +16,12 @@ interface UserInterface extends SymfonyUserInterface
         array $roles
     ): self;
 
-    public function getName();
+    public function getName(): string;
 
-    public function getExternalId();
+    public function getExternalId(): string;
 
-    public function getOrigin();
+    public function getOrigin(): string;
 
     /** @param string[] $roles */
-    public function setRoles(array $roles);
+    public function setRoles(array $roles): void;
 }

--- a/src/Event/LoginEvent.php
+++ b/src/Event/LoginEvent.php
@@ -2,7 +2,7 @@
 
 namespace SumoCoders\OAuthBundle\Event;
 
-use SumoCoders\OAuthBundle\Entity\User;
+use SumoCoders\OAuthBundle\Entity\UserInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class LoginEvent extends Event
@@ -10,12 +10,12 @@ class LoginEvent extends Event
     public const NAME = 'sumocoders.oauth.login';
 
     public function __construct(
-        private readonly User $user,
+        private readonly UserInterface $user,
         private readonly string $origin,
     ) {
     }
 
-    public function getUser(): User
+    public function getUser(): UserInterface
     {
         return $this->user;
     }

--- a/src/Security/AzureAuthenticator.php
+++ b/src/Security/AzureAuthenticator.php
@@ -36,19 +36,22 @@ class AzureAuthenticator extends OAuth2Authenticator implements AuthenticationEn
         private readonly ClientRegistry $clientRegistry,
         private readonly UserRepository $userRepository,
         private readonly RouterInterface $router,
+        private readonly string $client = 'azure',
+        private ?string $routePrefix = null,
         private readonly string $successRoute = 'home',
         private readonly string $failureRoute = 'home',
     ) {
+        $this->routePrefix ??= ($this->client === 'azure' ? '' : $this->client . '_');
     }
 
     public function supports(Request $request): ?bool
     {
-        return $request->attributes->get('_route') === 'connect_azure_check';
+        return $request->attributes->get('_route') === ($this->routePrefix . 'connect_azure_check');
     }
 
     public function authenticate(Request $request): Passport
     {
-        $client = $this->clientRegistry->getClient('azure');
+        $client = $this->clientRegistry->getClient($this->client);
         $accessToken = $this->fetchAccessToken($client);
 
         return new SelfValidatingPassport(
@@ -125,7 +128,7 @@ class AzureAuthenticator extends OAuth2Authenticator implements AuthenticationEn
     public function start(Request $request, ?AuthenticationException $authException = null): Response
     {
         return new RedirectResponse(
-            $this->router->generate('connect_azure_start'),
+            $this->router->generate($this->routePrefix . 'connect_azure_start'),
             Response::HTTP_TEMPORARY_REDIRECT
         );
     }

--- a/src/Security/AzureAuthenticator.php
+++ b/src/Security/AzureAuthenticator.php
@@ -40,7 +40,7 @@ class AzureAuthenticator extends OAuth2Authenticator implements AuthenticationEn
         private readonly RequestStack $requestStack,
         private readonly TranslatorInterface $translator,
         private readonly ClientRegistry $clientRegistry,
-        private readonly EntityManagerInterface $em,
+        private readonly EntityManagerInterface $entityManager,
         private readonly RouterInterface $router,
         private readonly string $userClass = User::class,
         private readonly string $client = 'azure',
@@ -73,14 +73,14 @@ class AzureAuthenticator extends OAuth2Authenticator implements AuthenticationEn
                 }
 
                 /** @var ?UserInterface $existingUser */
-                $existingUser = $this->em->getRepository($this->userClass)->findOneBy([
+                $existingUser = $this->entityManager->getRepository($this->userClass)->findOneBy([
                     'externalId' => $azureUser->getId(),
                     'origin' => self::ORIGIN,
                 ]);
 
                 if ($existingUser) {
                     $existingUser->setRoles($roles);
-                    $this->em->flush();
+                    $this->entityManager->flush();
 
                     $this->eventDispatcher->dispatch(
                         new LoginEvent($existingUser, self::ORIGIN)
@@ -96,8 +96,8 @@ class AzureAuthenticator extends OAuth2Authenticator implements AuthenticationEn
                     $roles
                 );
 
-                $this->em->persist($user);
-                $this->em->flush();
+                $this->entityManager->persist($user);
+                $this->entityManager->flush();
 
                 $this->eventDispatcher->dispatch(
                     new LoginEvent($user, self::ORIGIN)

--- a/src/Security/AzureAuthenticator.php
+++ b/src/Security/AzureAuthenticator.php
@@ -2,8 +2,11 @@
 
 namespace SumoCoders\OAuthBundle\Security;
 
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
 use Psr\Log\LoggerInterface;
 use SumoCoders\OAuthBundle\Entity\User;
+use SumoCoders\OAuthBundle\Entity\UserInterface;
 use SumoCoders\OAuthBundle\Event\LoginEvent;
 use SumoCoders\OAuthBundle\Repository\UserRepository;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
@@ -28,14 +31,18 @@ class AzureAuthenticator extends OAuth2Authenticator implements AuthenticationEn
 {
     public const ORIGIN = 'azure';
 
+    /**
+     * @param class-string<UserInterface> $userClass
+     */
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly RequestStack $requestStack,
         private readonly TranslatorInterface $translator,
         private readonly ClientRegistry $clientRegistry,
-        private readonly UserRepository $userRepository,
+        private readonly EntityManagerInterface $em,
         private readonly RouterInterface $router,
+        private readonly string $userClass = User::class,
         private readonly string $client = 'azure',
         private ?string $routePrefix = null,
         private readonly string $successRoute = 'home',
@@ -65,14 +72,15 @@ class AzureAuthenticator extends OAuth2Authenticator implements AuthenticationEn
                     $roles = [];
                 }
 
-                $existingUser = $this->userRepository->findOneBy([
+                /** @var ?UserInterface $existingUser */
+                $existingUser = $this->em->getRepository($this->userClass)->findOneBy([
                     'externalId' => $azureUser->getId(),
                     'origin' => self::ORIGIN,
                 ]);
 
                 if ($existingUser) {
                     $existingUser->setRoles($roles);
-                    $this->userRepository->save($existingUser, true);
+                    $this->em->flush();
 
                     $this->eventDispatcher->dispatch(
                         new LoginEvent($existingUser, self::ORIGIN)
@@ -81,14 +89,15 @@ class AzureAuthenticator extends OAuth2Authenticator implements AuthenticationEn
                     return $existingUser;
                 }
 
-                $user = new User(
+                $user = $this->userClass::fromAzure(
                     $azureUser->claim('preferred_username'),
                     $azureUser->getId(),
                     self::ORIGIN,
                     $roles
                 );
 
-                $this->userRepository->save($user, true);
+                $this->em->persist($user);
+                $this->em->flush();
 
                 $this->eventDispatcher->dispatch(
                     new LoginEvent($user, self::ORIGIN)


### PR DESCRIPTION
- Support multiple azure applications
- Allow using a different user entity

## Summary by Sourcery

Enable multiple Azure OAuth clients with configurable client names, route prefixes, and user entity classes, and update documentation with setup examples.

New Features:
- Add support for multiple Azure OAuth clients by parameterizing the Authenticator with a client name and route prefix
- Introduce UserInterface and factory method to allow using custom user entity implementations

Enhancements:
- Refactor AzureAuthenticator to use EntityManager, dynamic client retrieval, and dynamic routes
- Update AzureController to select the OAuth client based on the route prefix
- Add static fromAzure factory method to User entity and switch LoginEvent to use UserInterface

Documentation:
- Expand README with configuration examples for multiple clients, environment variables, routes, and services