### PR TITLE
add symfony 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
         "php": "^8.2",
         "knpuniversity/oauth2-client-bundle": "^2.14",
         "thenetworg/oauth2-azure": "^2.1",
-        "symfony/dependency-injection": "^7.1",
-        "symfony/security-bundle": "^7.1",
+        "symfony/dependency-injection": "^^7.1 || ^8.0",
+        "symfony/security-bundle": "^^7.1 || ^8.0",
         "doctrine/doctrine-bundle": "^2.9",
         "doctrine/orm": "^2.14 || ^3.3",
-        "symfony/translation": "^7.1"
+        "symfony/translation": "^7.1 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Updated Symfony dependency constraints to support Symfony 8.

Changed `^7.1` to `^7.1 || ^8.0` for:
- symfony/dependency-injection
- symfony/security-bundle
- symfony/translation